### PR TITLE
Check if paths should/could be resolved

### DIFF
--- a/file/src/main/java/org/expath/file/ResolvePath.java
+++ b/file/src/main/java/org/expath/file/ResolvePath.java
@@ -18,7 +18,7 @@ package org.expath.file;
  */
 
 import java.io.File;
-
+import java.nio.file.Paths;
 import net.sf.saxon.expr.XPathContext;
 import net.sf.saxon.lib.ExtensionFunctionCall;
 import net.sf.saxon.om.Sequence;
@@ -77,9 +77,14 @@ public class ResolvePath extends FileFunctionDefinition {
         
     @Override
     public StringValue call(XPathContext context, Sequence[] arguments) throws XPathException {                  
-      String relPath = ((StringValue) arguments[0].head()).getStringValue();                        
-      String fullPath = new File(System.getProperty("user.dir"), relPath).toString();                           
-      return new StringValue(fullPath);     
+      String relPath = ((StringValue) arguments[0].head()).getStringValue();
+      if (Paths.get(relPath).isAbsolute()) {
+        return new StringValue(relPath);
+      }
+      else {
+        String fullPath = new File(System.getProperty("user.dir"), relPath).toString();
+        return new StringValue(fullPath);
+      }
     } 
   }
 }


### PR DESCRIPTION
#4 

I was a bit unsure if maybe just replacing `String fullpath = ...` with 

```
        String fullPath = Paths.get(relPath).toAbsolutePath().normalize().toString();
``` 
(from looking at the basex implementation) is better, but I didn't discover it before this initial pull request.

Does the change introduce any new bugs for current usage?